### PR TITLE
fix(statblock): Support statblock abilities in two line format

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -267,9 +267,11 @@ function getParser(formatSpec, logger) {
         if (_.isEmpty(textLines)) {
           return false;
         }
+        textLines[0] = textLines[0].trim();
+
         var re = new RegExp('^([\\sa-z\\(\\)]*)(\\d+(?:\\s?\\([\\-+\\d]+\\))?)', 'i');
         logger.debug('Attempting to match value [$$$] against regexp $$$', textLines[0].trim(), re.toString());
-        var match = textLines[0].trim().match(re);
+        var match = textLines[0].match(re);
 
         if (match) {
           logger.debug('Successful match $$$', match);
@@ -279,6 +281,23 @@ function getParser(formatSpec, logger) {
             textLines.shift();
           }
           return true;
+        }
+        else if (textLines[1]) {
+          //Try and match against the next line in case we have a two line format
+          textLines[1] = textLines[1].trim();
+          match = textLines[1].match(/^(\d+)(?:\s?\([\-+\d]+\))?/);
+          if (match) {
+            logger.debug('Successful ability match $$$ on next line - looks like two line format', match);
+            parseState.text = match[1];
+            textLines[1] = textLines[1].slice(match[0].length);
+            if (!textLines[0]) {
+              textLines.shift();
+            }
+            if (!textLines[0]) {
+              textLines.shift();
+            }
+            return true;
+          }
         }
         return false;
       };

--- a/lib/sanitise.js
+++ b/lib/sanitise.js
@@ -5,6 +5,7 @@ function sanitise(statblock, logger) {
     .replace(/\s+([\.,;:])/g, '$1')
     .replace(/\n+/g, '#')
     .replace(/–/g, '-')
+    .replace(/−/g, '-') //Watch out: this and the line above containing funny unicode versions of '-'
     .replace(/<br[^>]*>/g, '#')
     .replace(/#+/g, '#')
     .replace(/\s*#\s*/g, '#')

--- a/test/data/halfDragonTroll.json
+++ b/test/data/halfDragonTroll.json
@@ -1,0 +1,54 @@
+{
+  "monsters": [
+    {
+      "name": "Half-Dragon Troll",
+      "size": "Large",
+      "type": "giant",
+      "alignment": "chaotic evil",
+      "AC": "15 (natural armor)",
+      "HP": "84 (8d10 + 40)",
+      "speed": "30 ft",
+      "strength": 18,
+      "dexterity": 13,
+      "constitution": 20,
+      "intelligence": 7,
+      "wisdom": 9,
+      "charisma": 7,
+      "skills": "Perception +1",
+      "damageResistances": "acid",
+      "senses": "blindsight 10 ft, darkvision 60 ft",
+      "languages": "Draconic, Giant",
+      "challenge": "5",
+      "traits": [
+        {
+          "name": "Keen Smell",
+          "text": "The half-dragon troll has advantage on Wisdom (Perception) checks that rely on smell."
+        },
+        {
+          "name": "Regeneration",
+          "text": "The half-dragon troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with 0 hit points and doesn't regenerate."
+        }
+      ],
+      "actions": [
+        {
+          "name": "Multiattack",
+          "text": "The half-dragon troll makes three attacks: one with its bite and two with its claws."
+        },
+        {
+          "name": "Bite",
+          "text": "Melee Weapon Attack: +7 to hit, reach 5 ft, one target. Hit: 7 (1d6 + 4) piercing damage."
+        },
+        {
+          "name": "Claw",
+          "text": "Melee Weapon Attack: +7 to hit, reach 5 ft, one target. Hit: 11 (2d6 + 4) slashing damage."
+        },
+        {
+          "name": "Acid Breath",
+          "recharge": "Recharge 5-6",
+          "text": "The half-dragon troll exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one."
+        }
+      ]
+    }
+  ],
+  "version": "0.2"
+}

--- a/test/data/halfDragonTroll.txt
+++ b/test/data/halfDragonTroll.txt
@@ -1,0 +1,19 @@
+Half-Dragon Troll
+Large giant, chaotic evil
+Armor Class 15 (natural armor)
+Hit Points 84 (8d10 + 40)
+Speed 30 ft.
+STR DEX CON INT WIS CHA
+18 (+4) 13 (+1) 20 (+5) 7 (−2) 9 (−1) 7 (−2)
+Skills Perception +1
+Damage Resistances acid
+Senses blindsight 10 ft., darkvision 60 ft., passive Perception 11
+Languages Draconic, Giant
+Challenge 5 (1,800 XP)
+Keen Smell. The half-dragon troll has advantage on Wisdom (Perception) checks that rely on smell.
+Regeneration. The half-dragon troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn’t function at the start of the troll’s next turn. The troll dies only if it starts its turn with 0 hit points and doesn’t regenerate.
+Actions
+Multiattack. The half-dragon troll makes three attacks: one with its bite and two with its claws.
+Bite. Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.
+Claw. Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.
+Acid Breath (Recharge 5-6). The half-dragon troll exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one.


### PR DESCRIPTION
Fix parsing where ability names appear on one line and values appear below them. Also added a
replacement for yet another unicode minus character that confused the parser.

fixes: #29