### PR TITLE
fix(hpRoll): Fix hp rolling to respect max setting for token bar

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -772,7 +772,9 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
           var total = results[0].inlinerolls[0].results.total;
           roll20.sendChat('HP Roller', '/w GM &{template:5e-shaped} ' + message);
           token.set(hpBar + '_value', total);
-          token.set(hpBar + '_max', total);
+          if (myState.config.tokenSettings[hpBar].max) {
+            token.set(hpBar + '_max', total);
+          }
         }
       }
     });


### PR DESCRIPTION
Fix HP rolling so that if max is false for the HP bar, it won't populate a max value.

Fixes #23