### PR TITLE
fix(abilities): Changed to not create a macro action when there are no corresponding actions.

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -1096,6 +1096,19 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
     this.sortKey = 'originalOrder';
   };
 
+  var RepeatingSectionMacroMaker = function (abilityName, repeatingSection, macroName) {
+    this.run = function (character, options) {
+      if (!_.isEmpty(roll20.getRepeatingSectionAttrs(character.id, repeatingSection))) {
+        return getAbilityMaker(character)({
+          name: macroName,
+          action: '%{' + character.get('name') + '|' + abilityName + '}'
+        });
+      }
+      return `${macroName}: Not present for character`;
+    };
+    this.sortKey = 'originalOrder';
+  };
+
   var staticAbilityOptions = {
     DELETE: abilityDeleter,
     initiative: new RollAbilityMaker('initiative', 'Init'),
@@ -1110,18 +1123,19 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
     attacks: new RepeatingAbilityMaker('attack', 'attack', 'Attacks', true),
     statblock: new RollAbilityMaker('statblock', 'Statblck'),
     traits: new RepeatingAbilityMaker('trait', 'trait', 'Traits'),
-    'traits-macro': new RollAbilityMaker('traits_macro', 'Traits'),
+    'traits-macro': new RepeatingSectionMacroMaker('traits_macro', 'trait', 'Traits'),
     actions: new RepeatingAbilityMaker('action', 'action', 'Actions', true),
-    'actions-macro': new RollAbilityMaker('actions_macro', 'Actions'),
+    'actions-macro': new RepeatingSectionMacroMaker('actions_macro', 'action', 'Actions'),
     reactions: new RepeatingAbilityMaker('reaction', 'action', 'Reactions'),
-    'reactions-macro': new RollAbilityMaker('reactions_macro', 'Reactions'),
+    'reactions-macro': new RepeatingSectionMacroMaker('reactions_macro', 'reaction', 'Reactions'),
     legendaryactions: new RepeatingAbilityMaker('legendaryaction', 'action', 'Legendary Actions'),
-    'legendaryactions-macro': new RollAbilityMaker('legendaryactions_macro', 'Legendary Actions'),
+    'legendaryactions-macro': new RepeatingSectionMacroMaker('legendaryactions_macro', 'legendaryaction', 'Legendary' +
+      ' Actions'),
     legendarya: new RepeatingAbilityMaker('legendaryaction', 'action', 'LegendaryA'),
-    lairactions: new RollAbilityMaker('lairactions_macro', 'Lair Actions'),
-    laira: new RollAbilityMaker('lairactions_macro', 'LairA'),
-    regionaleffects: new RollAbilityMaker('regionaleffects_macro', 'Regional Effects'),
-    regionale: new RollAbilityMaker('regionaleffects_macro', 'RegionalE')
+    lairactions: new RepeatingSectionMacroMaker('lairactions_macro', 'lairaction', 'Lair Actions'),
+    laira: new RepeatingSectionMacroMaker('lairactions_macro', 'lairaction', 'LairA'),
+    regionaleffects: new RepeatingSectionMacroMaker('regionaleffects_macro', 'regionaleffect', 'Regional Effects'),
+    regionale: new RepeatingSectionMacroMaker('regionaleffects_macro', 'regionaleffect', 'RegionalE')
   };
 
   var abilityLookup = function (optionName, existingOptions) {


### PR DESCRIPTION

For macro actions, the script used to output a token action whether or not there were items
in the corresponding repeating section. Change this.

Fixes #2