### PR TITLE
fix(spell-import): Make it expand all gender pronoun placeholders in the emote

### DIFF
--- a/lib/srd-converter.js
+++ b/lib/srd-converter.js
@@ -249,7 +249,7 @@ module.exports = {
       if (converted.emote) {
         _.each(pronounTokens, function (pronounType, token) {
           var replacement = pronounInfo[pronounType];
-          converted.emote = converted.emote.replace(token, replacement);
+          converted.emote = converted.emote.replace(new RegExp(token, 'g'), replacement);
         });
       }
       return converted;


### PR DESCRIPTION

Only the the first gender pronoun placeholder of each type was being replaced in spell emotes.
Add a '/g' to fix this.

fixes #39