### PR TITLE
feat(statblock-import): Read statblocks from character GM notes as well as tokens.

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -372,18 +372,38 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
     logger.info('Importing statblocks for tokens $$$', options.selected.graphic);
     var self = this;
     _.each(options.selected.graphic, function (token) {
+      const error = `Could not find GM notes on either selected token ${token.get('name')} or the character it represents. Have you` +
+        ' pasted it in correctly?';
       var text = token.get('gmnotes');
-      if (text) {
-        text = sanitise(unescape(text), logger);
-        var monsters = parser.parse(text).monsters;
-        mpp(monsters, entityLookup);
-        self.importMonsters(monsters, options, token, [
-          function (character) {
-            character.set('gmnotes', text.replace(/\n/g, '<br>'));
-          }
-        ]);
+      if (!text) {
+        const char = roll20.getObj('character', token.get('represents'));
+        if (char) {
+          char.get('gmnotes', notes => {
+            if (notes) {
+              return self.processGMNotes(options, token, notes);
+            }
+            reportError(error);
+          });
+        }
+        else {
+          reportError(error);
+        }
+      }
+      else {
+        self.processGMNotes(options, token, text);
       }
     });
+  };
+
+  this.processGMNotes = function (options, token, text) {
+    text = sanitise(unescape(text), logger);
+    var monsters = parser.parse(text).monsters;
+    mpp(monsters, entityLookup);
+    self.importMonsters(monsters, options, token, [
+      function (character) {
+        character.set('gmnotes', text.replace(/\n/g, '<br>'));
+      }
+    ]);
   };
 
   this.importMonstersFromJson = function (options) {


### PR DESCRIPTION

If the selected token has no gm notes, read them from the character represented by the token.
Report an error in chat if no gm notes found.

fixes: #1