### PR TITLE
fix(abilities): Don't create lots of junk token actions for multiple tokens from same char

### DIFF
--- a/lib/command-parser.js
+++ b/lib/command-parser.js
@@ -186,6 +186,7 @@ function processSelection(selection, constraints) {
         return object;
       })
       .compact()
+      .uniq()
       .value();
     if (_.size(objects) < constraintDetails.min || _.size(objects) > constraintDetails.max) {
       throw 'Wrong number of objects of type [' + type + '] selected, should be between ' + constraintDetails.min +

--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -1033,7 +1033,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
 
   this.addAbility = function (options) {
     if (_.isEmpty(options.abilities)) {
-      //TODO report some sort of error?
+      reportError('No abilities specified. Take a look at the documentation for a list of ability options.');
       return;
     }
     var messages = _.map(options.selected.character, function (character) {


### PR DESCRIPTION

The script would generate lots of blank token actions when you asked it to create token
actions with multiple tokens for the same character selected. Prevent it doing this.

fixes: #5