### PR TITLE
fix(command-parser): Report errors for unresolved options when comma-separated

### DIFF
--- a/lib/command-parser.js
+++ b/lib/command-parser.js
@@ -107,22 +107,34 @@ Command.prototype.optionLookup = function (groupName, lookup) {
   }
   this.parsers.push(function (arg, errors, options) {
     options[groupName] = options[groupName] || [];
-    var someMatch = false;
-    var resolved = lookup(arg, options);
-    if (resolved) {
-      options[groupName].push(resolved);
-      someMatch = true;
+    const singleResolved = lookup(arg, options);
+    if (singleResolved) {
+      options[groupName].push(singleResolved);
+      return true;
     }
-    else {
-      _.each(arg.split(','), function (name) {
-        var resolved = lookup(name.trim(), options);
-        if (resolved) {
-          options[groupName].push(resolved);
-          someMatch = true;
+
+
+    const results = _.chain(arg.split(','))
+      .map(_.partial(_.result, _, 'trim'))
+      .uniq()
+      .reduce(function (results, name) {
+        const resolvedPart = lookup(name, options);
+        if (resolvedPart) {
+          results.resolved.push(resolvedPart);
         }
-      });
+        else {
+          results.errors.push(`Unrecognised item ${name} for option group ${groupName}`);
+        }
+        return results;
+      }, { errors: [], resolved: [] })
+      .value();
+
+    if (!_.isEmpty(results.resolved)) {
+      options[groupName] = results.resolved;
+      errors.push.apply(errors, results.errors);
+      return true;
     }
-    return someMatch;
+    return false;
   });
   return this;
 };

--- a/test/test-command-parser.js
+++ b/test/test-command-parser.js
@@ -49,5 +49,36 @@ describe('command-parser', function () {
       expected.foo.subThree.flurb[1] = 'splat';
       expect(result).to.deep.equal(expected);
     });
+
+  });
+
+  describe('#optionLookup', function () {
+    var lookup = {
+      key1: 'value1',
+      key2: 'value2'
+    };
+    var result = {};
+    const myCp = cp('shaped')
+      .addCommand('stuff', function (object) {
+        result = object;
+      })
+      .optionLookup('spells', function (option) {
+        return lookup[option];
+      })
+      .end();
+
+    it('handles comma-sep options', function () {
+      myCp.processCommand({ content: '!shaped-stuff --key1, key2', type: 'api' });
+      expect(result).to.deep.equal({
+        selected: undefined,
+        spells: ['value1', 'value2']
+      });
+    });
+
+    it('handles partial error with comma-sep options', function () {
+      expect(myCp.processCommand.bind(myCp, { content: '!shaped-stuff --key1, key4', type: 'api' }))
+        .to.throw('Unrecognised item key4 for option group spells');
+    });
+
   });
 });


### PR DESCRIPTION

Previously, the command parser would silently drop values passed as part of a comma-separated
set on the command line (e.g. --Fireball, Unknown Spell, Cure Wounds). Change to report an
error for any unknown option to avoid bemusement.

fixes: #8