### PR TITLE
fix: Irrelevant command line arguments are no longer saved to state

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -330,6 +330,8 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter) 
   // Command handlers
   /////////////////////////////////////////
   this.configure = function (options) {
+    // drop "menu" options
+    options = _.omit(options, ['atMenu', 'tsMenu', 'ncMenu', 'seMenu']);
     utils.deepExtend(myState.config, options);
 
     var cui = new ConfigUI();


### PR DESCRIPTION
irrelevant command line arguments are no longer saved to state when calling config menus, closes #34