### PR TITLE
feat(hpRolling): Set values for all non-linked attributes, not just HP

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -520,7 +520,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     const defaultIndex = Math.min(myState.config.defaultGenderIndex, myState.config.genderPronouns.length);
     const defaultPronounInfo = myState.config.genderPronouns[defaultIndex];
     const pronounInfo = _.clone(_.find(myState.config.genderPronouns,
-      pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
+        pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
 
     _.defaults(pronounInfo, defaultPronounInfo);
 
@@ -536,7 +536,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
 
 
   this.monsterDataPopulator = function monsterDataPopulator(character, monsterData) {
-    _.each(myState.config.newCharSettings, (value, key) => {
+    _.each(utils.flattenObject(myState.config.newCharSettings), (value, key) => {
       const attribute = roll20.getOrCreateAttr(character.id, configToAttributeLookup[key]);
       attribute.set('current', _.isBoolean(value) ? (value ? 'on' : 0) : value);
     });
@@ -733,68 +733,63 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
         }
       };
       /* eslint-disable no-spaced-func */
-    } (token.id)), 100);
+    }(token.id)), 100);
   };
 
   this.handleChangeToken = function handleChangeToken(token) {
     if (_.contains(addedTokenIds, token.id)) {
       addedTokenIds = _.without(addedTokenIds, token.id);
-      this.rollHPForToken(token);
+      this.setTokenBarsOnDrop(token);
       at.handleTokenChange(token);
     }
   };
 
-  this.getHPBar = function getHPBar() {
-    return _.chain(myState.config.tokenSettings)
-      .pick('bar1', 'bar2', 'bar3')
-      .findKey({ attribute: 'HP' })
-      .value();
-  };
-
-  this.rollHPForToken = function rollHPForToken(token) {
-    const hpBar = this.getHPBar();
-    logger.debug('HP bar is $$$', hpBar);
-    if (!hpBar || !myState.config.sheetEnhancements.rollHPOnDrop) {
-      return;
-    }
-
-    const represents = token.get('represents');
-    if (!represents) {
-      return;
-    }
-    const character = roll20.getObj('character', represents);
+  this.setTokenBarsOnDrop = function setTokenBarsOnDrop(token) {
+    const character = roll20.getObj('character', token.get('represents'));
     if (!character) {
       return;
     }
-    const hpBarLink = token.get(`${hpBar}_link`);
-    if (hpBarLink) {
-      return;
-    }
-    // Guard against characters that aren't properly configured - i.e. ones used for templates and system
-    // things rather than actual characters
-    if (_.isEmpty(roll20.getAttrByName(character.id, 'hp_formula'))) {
-      logger.debug('Ignoring character $$$ for rolling HP - has no hp_formula attribute', character.get('name'));
-      return;
-    }
 
-    roll20.sendChat('', `%{${character.get('name')}|npc_hp}`, results => {
-      if (results && results.length === 1) {
-        const message = this.processInlinerolls(results[0]);
-        if (!results[0].inlinerolls || !results[0].inlinerolls[0]) {
-          logger.warn('HP roll didn\'t have the expected structure. This is what we got back: $$$', results[0]);
-        }
-        else {
-          const total = results[0].inlinerolls[0].results.total;
-          roll20.sendChat('HP Roller', `/w GM &{template:5e-shaped} ${message}`);
-          token.set(`${hpBar}_value`, total);
-          if (myState.config.tokenSettings[hpBar].max) {
-            token.set(`${hpBar}_max`, total);
-          }
+    function setBar(barName, bar, value) {
+      if (value) {
+        token.set(`${barName}_value`, value);
+        if (bar.max) {
+          token.set(`${barName}_max`, value);
         }
       }
-    });
-  };
+    }
 
+    _.chain(myState.config.tokenSettings)
+      .pick('bar1', 'bar2', 'bar3')
+      .each((bar, barName) => {
+        if (bar.attribute && !token.get(`${barName}_link`)) {
+          if (bar.attribute === 'HP' && myState.config.sheetEnhancements.rollHPOnDrop) {
+            // Guard against characters that aren't properly configured - i.e. ones used for templates and system
+            // things rather than actual characters
+            if (_.isEmpty(roll20.getAttrByName(character.id, 'hp_formula'))) {
+              logger.debug('Ignoring character $$$ for rolling HP - has no hp_formula attribute',
+                character.get('name'));
+              return;
+            }
+            roll20.sendChat('', `%{${character.get('name')}|npc_hp}`, results => {
+              if (results && results.length === 1) {
+                const message = this.processInlinerolls(results[0]);
+                if (!results[0].inlinerolls || !results[0].inlinerolls[0]) {
+                  logger.warn('HP roll didn\'t have the expected structure. This is what we got back: $$$', results[0]);
+                }
+                else {
+                  roll20.sendChat('HP Roller', `/w GM &{template:5e-shaped} ${message}`);
+                  setBar(barName, bar, results[0].inlinerolls[0].results.total);
+                }
+              }
+            });
+          }
+          else {
+            setBar(barName, bar, roll20.getAttrByName(character.id, bar.attribute));
+          }
+        }
+      });
+  };
 
   this.registerChatWatcher = function registerChatWatcher(handler, triggerFields) {
     const matchers = [];
@@ -830,7 +825,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .groupBy(attribute => attribute.get('name').replace(/(repeating_ammo_[^_]+).*/, '$1'))
       .find(attributeList =>
         _.find(attributeList, attribute =>
-          attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
+        attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
       )
       .find(attribute => attribute.get('name').match(/.*qty$/))
       .value();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,4 +135,15 @@ module.exports = {
   missingParam(name) {
     throw new Error(`Parameter ${name} is required`);
   },
+
+  flattenObject(object) {
+    return _.reduce(object, (explodedProps, propVal, propKey) => {
+      if (_.isObject(propVal)) {
+        return _.extend(explodedProps, this.flattenObject(propVal));
+      }
+
+      explodedProps[propKey] = propVal;
+      return explodedProps;
+    }, {});
+  },
 };

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -46,4 +46,36 @@ describe('utils', function () {
       expect(result).to.deep.equal(expected);
     });
   });
+
+  describe('flattenObject', function () {
+    it('flattens object correctly', function () {
+      const input = {
+        key1: 'value1',
+        key2: 'value2',
+        key3: {
+          innerKey1: 'innerValue1',
+          innerKey2: {
+            innermostKey1: 'innermostValue1',
+            innermostKey2: 'innermostValue2',
+          },
+        },
+        key4: 'value4',
+        key5: {
+          innerKey3: 'innerValue3',
+        },
+        key6: 'value6',
+      };
+
+      expect(utils.flattenObject(input)).to.deep.equal({
+        key1: 'value1',
+        key2: 'value2',
+        innerKey1: 'innerValue1',
+        innermostKey1: 'innermostValue1',
+        innermostKey2: 'innermostValue2',
+        key4: 'value4',
+        innerKey3: 'innerValue3',
+        key6: 'value6',
+      });
+    });
+  });
 });


### PR DESCRIPTION
 Previously, the script would only look for an HP bar that was not linked, and set the token's
 bar based on rolling HP if that feature was enabled. Change so that it now copies all non-linked
 bar values from their respective attributes when token is dropped

fixes: #26