### PR TITLE
fix(spell-slots): Prevent error when normal spell slots are missing -…

### DIFF
--- a/lib/command-parser.js
+++ b/lib/command-parser.js
@@ -196,10 +196,7 @@ function processSelection(selection, constraints, roll20) {
       .map(selected => roll20.getObj(selected._type, selected._id))
       .map(object => {
         if (type === 'character' && object) {
-          const represents = object.get('represents');
-          if (represents) {
-            return roll20.getObj('character', represents);
-          }
+          return roll20.getObj('character', object.get('represents'));
         }
         return object;
       })

--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -942,9 +942,11 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
 
     const spellLevel = parseInt(options.friendlyLevel.slice(0, 1), 10);
     const level = options.castAsLevel ? parseInt(options.castAsLevel, 10) : spellLevel;
-    const availableSlots = _.range(spellLevel, 10)
+    const availableSlots = _.chain(_.range(spellLevel, 10))
       .map(slotLevel => roll20.getAttrObjectByName(options.character.id, `spell_slots_l${slotLevel}`))
-      .filter(attr => attr.get('current') > 0);
+      .compact()
+      .filter(attr => attr.get('current') > 0)
+      .value();
 
     const spellId = _.chain(roll20.getRepeatingSectionItemIdsByName(options.character.id, 'spell'))
       .pick(options.title.toLowerCase())


### PR DESCRIPTION
… e.g. for warlock spells.

Fixes: #68