### PR TITLE
feat: Add short/long rest command support

### DIFF
--- a/lib/rest-manager.js
+++ b/lib/rest-manager.js
@@ -1,0 +1,116 @@
+'use strict';
+const _ = require('underscore');
+
+class RestManager {
+
+  constructor(logger, myState, roll20) {
+    this.logger = logger;
+    this.myState = myState;
+    this.roll20 = roll20;
+  }
+
+  /**
+   * Performs all of the short rest actions for the specified character
+   * @param {collection of characters} selectedChars - The characters to perform short rest actions on
+   */
+  doShortRest(selectedChars) {
+    _.each(selectedChars, (currentChar) => {
+      const charId = currentChar.get('_id');
+      this.logger.debug(`Processing short rest for ${this.roll20.getObj('character', charId).get('name')}:`);
+
+      this.rechargeTraits(charId, 'Short Rest');
+    });
+  }
+
+  /**
+   * Performs all of the long rest actions for the specified character - including short rest actions
+   * @param {collection of characters} selectedChars - The characters to perform long rest actions on
+   */
+  doLongRest(selectedChars) {
+    _.each(selectedChars, (currentChar) => {
+      const charId = currentChar.get('_id');
+      this.logger.debug(`Processing long rest for ${this.roll20.getObj('character', charId).get('name')}:`);
+
+      this.rechargeTraits(charId, 'Short Rest');
+      this.rechargeTraits(charId, 'Long Rest');
+
+      this.resetHP(charId);
+
+      this.regainHitDie(charId);
+
+      this.regainSpellSlots(charId);
+    });
+  }
+
+  /**
+   * Recharges all of the repeating 'traits' section items that have a 'recharge' defined
+   * @param {string} charId - the Roll20 character ID
+   * @param {string} restType - the type of rest being performed; either 'Short Rest' or 'Long Rest'
+   */
+  rechargeTraits(charId, restType) {
+    _.chain(this.roll20.findObjs({ type: 'attribute', characterid: charId }))
+      .map(attribute => (attribute.get('name').match(/^repeating_trait_([^_]+)_recharge$/) || [])[1])
+      .reject(_.isUndefined)
+      .uniq()
+      .each(attId => {
+        const traitPre = `repeating_trait_${attId}`;
+        const rechargeAtt = this.roll20.getAttrByName(charId, `${traitPre}_recharge`);
+        if (rechargeAtt === restType) {
+          const attName = this.roll20.getAttrByName(charId, `${traitPre}_name`);
+          this.logger.debug(`Recharging '${attName}'`);
+          const max = this.roll20.getAttrByName(charId, `${traitPre}_uses`, 'max');
+          this.roll20.setAttrByName(charId, `${traitPre}_uses`, max);
+        }
+      });
+  }
+
+  /**
+   * Resets the HP of the specified character to its maximum value
+   * @param {string} charId - the Roll20 character ID
+   */
+  resetHP(charId) {
+    this.logger.debug('Resetting HP to max');
+    const max = this.roll20.getAttrByName(charId, 'HP', 'max');
+    this.roll20.setAttrByName(charId, 'HP', max);
+  }
+
+  /**
+   * Adds Hit die to the specified character based on PHB rules
+   * @param {string} charId - the Roll20 character ID
+   */
+  regainHitDie(charId) {
+    this.logger.debug('Regaining Hit Die');
+    _.chain(this.roll20.findObjs({ type: 'attribute', characterid: charId }))
+      .filter(attribute => (attribute.get('name').match(/^hd_d\d{1,2}$/)))
+      .uniq()
+      .each(hdAttr => {
+        const max = parseInt(hdAttr.get('max'), 10);
+        if (max > 0) {
+          const current = parseInt(hdAttr.get('current'), 10);
+          let newCurrent = current;
+          const regained = max === 1 ? 1 : Math.floor(max / 2);
+          newCurrent += regained;
+          this.roll20.setAttrByName(charId, hdAttr.get('name'), newCurrent > max ? max : newCurrent);
+        }
+      });
+  }
+
+  /**
+   * Resets all (non warlock) spell slots of the specified character to their maximum valus
+   * @param {string} charId - the Roll20 character ID
+   */
+  regainSpellSlots(charId) {
+    this.logger.debug('Regaining Spell Slots');
+    _.chain(this.roll20.findObjs({ type: 'attribute', characterid: charId }))
+      .filter(attribute => (attribute.get('name').match(/^spell_slots_l\d$/)))
+      .uniq()
+      .each(slotAttr => {
+        const max = parseInt(slotAttr.get('max'), 10);
+        if (max > 0) {
+          this.roll20.setAttrByName(charId, slotAttr.get('name'), max);
+        }
+      });
+  }
+}
+
+module.exports = RestManager;

--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -5,6 +5,7 @@ const parseModule = require('./parser');
 const cp = require('./command-parser');
 const utils = require('./utils');
 const AdvantageTracker = require('./advantage-tracker');
+const RestManager = require('./rest-manager');
 const ConfigUI = require('./config-ui');
 const Logger = require('roll20-logger');
 const UserError = require('./user-error');
@@ -342,6 +343,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
   const reportError = reporter.reportError.bind(reporter);
   const chatWatchers = [];
   const at = new AdvantageTracker(logger, myState, roll20);
+  const rester = new RestManager(logger, myState, roll20);
 
   /**
    *
@@ -542,7 +544,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     const defaultIndex = Math.min(myState.config.defaultGenderIndex, myState.config.genderPronouns.length);
     const defaultPronounInfo = myState.config.genderPronouns[defaultIndex];
     const pronounInfo = _.clone(_.find(myState.config.genderPronouns,
-        pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
+      pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
 
     _.defaults(pronounInfo, defaultPronounInfo);
 
@@ -877,7 +879,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .groupBy(attribute => attribute.get('name').replace(/(repeating_ammo_[^_]+).*/, '$1'))
       .find(attributeList =>
         _.find(attributeList, attribute =>
-        attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
+          attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
       )
       .find(attribute => attribute.get('name').match(/.*qty$/))
       .value();
@@ -926,6 +928,20 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     }
   };
 
+  this.handleRest = function handleRest(options) {
+    if (options.long) {
+      // handle long rest
+      rester.doLongRest(options.selected.character);
+    }
+    else if (options.short) {
+      // handle short rest
+      rester.doShortRest(options.selected.character);
+    }
+    else {
+      this.roll20.reportError('please specify long (!shaped-rest --long) or short (!shaped-rest --short) rest');
+    }
+  };
+
   this.handleD20Roll = function handleD20Roll(options) {
     if (options.disadvantage || options.advantage) {
       const autoRevertOptions = roll20.getAttrByName(options.character.id, 'auto_revert_advantage');
@@ -961,7 +977,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     let msg;
 
     const bestSlot = availableSlots
-        .find(slot => parseInt(slot.get('name').match(/spell_slots_l(\d)/)[1], 10) === level) ||
+      .find(slot => parseInt(slot.get('name').match(/spell_slots_l(\d)/)[1], 10) === level) ||
       _.first(availableSlots);
 
     if (bestSlot) {
@@ -1302,7 +1318,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
 
   this.getCommandProcessor = function getCommandProcessor() {
     return cp('shaped', roll20)
-    // !shaped-config
+      // !shaped-config
       .addCommand('config', this.configure.bind(this))
       .options(configOptionsSpec)
       .option('atMenu', booleanValidator)
@@ -1377,6 +1393,16 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .option('character', getCharacterValidator(roll20), true)
       .option('use', integerValidator)
       .option('restore', integerValidator)
+      // !shaped-rest
+      .addCommand('rest', this.handleRest.bind(this))
+      .option('long', booleanValidator)
+      .option('short', booleanValidator)
+      .withSelection({
+        character: {
+          min: 1,
+          max: Infinity,
+        },
+      })
       .end();
   };
 


### PR DESCRIPTION
`!shaped-rest --short` will perform a 'short rest' action on the character(s) associated with the currently selected token(s):
- Reset all 'traits' with a 'Short Rest' recharge uses to the max value

`!shaped-rest --long` will perform a 'long rest' action on the character(s) associated with the currently selected token(s):
- All 'short rest' actions
- Reset all 'traits' with a 'Long Rest' recharge uses to the max value
- HP set to max
- Spell Slots (non warlock) set to max
- Regain the appropriate number of hit die

fixes: #17