### PR TITLE
fix(config): Fix up bad values in option lists

### DIFF
--- a/lib/config-ui.js
+++ b/lib/config-ui.js
@@ -147,7 +147,7 @@ class ConfigUi {
     const ncs = 'newCharSettings';
 
     const optionRows = this.makeQuerySetting(config, `${ncs}.sheetOutput`, 'Sheet Output',
-      optionsSpec.newCharSettings.sheetOutput()) +
+        optionsSpec.newCharSettings.sheetOutput()) +
       this.makeQuerySetting(config, `${ncs}.deathSaveOutput`,
         'Death Save Output', optionsSpec.newCharSettings.deathSaveOutput()) +
       this.makeQuerySetting(config, `${ncs}.initiativeOutput`, 'Initiative Output',
@@ -233,7 +233,7 @@ class ConfigUi {
     }
 
     return this.makeOptionRow(title, path, `?{${prompt}|${currentVal}}`, emptyHint, 'click to edit', emptyHint ===
-      '[not set]' ? '#f84545' : '#02baf2');
+    '[not set]' ? '#f84545' : '#02baf2');
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -262,8 +262,14 @@ class ConfigUi {
   }
 
   makeQuerySetting(config, path, title, optionsSpec) {
-    const currentVal = _.invert(optionsSpec)[utils.getObjectFromPath(config, path)];
+    let currentVal = _.invert(optionsSpec)[utils.getObjectFromPath(config, path)];
     const optionList = _.keys(optionsSpec);
+
+    // Fix up if we've somehow ended up with an illegal value
+    if (_.isUndefined(currentVal)) {
+      currentVal = _.first(optionList);
+      utils.deepExtend(config, utils.createObjectFromPath(path, optionsSpec[currentVal]));
+    }
 
     // move the current option to the front of the list
     optionList.splice(optionList.indexOf(currentVal), 1);


### PR DESCRIPTION
Sometimes it appears that people can end up with bad values in their config for option
lists - e.g. one guy somehow had the wrong thing for his rollOptions. This was breaking the
UI previously, so change it to replace these bad values with the first value in the list.