### PR TITLE
feat(AT): Support passing character ID

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -494,7 +494,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     const defaultIndex = Math.min(myState.config.defaultGenderIndex, myState.config.genderPronouns.length);
     const defaultPronounInfo = myState.config.genderPronouns[defaultIndex];
     const pronounInfo = _.clone(_.find(myState.config.genderPronouns,
-        pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
+      pronounDetails => new RegExp(pronounDetails.matchPattern, 'i').test(gender)) || defaultPronounInfo);
 
     _.defaults(pronounInfo, defaultPronounInfo);
 
@@ -714,6 +714,11 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
   this.handleAdvantageTracker = function handleAdvantageTracker(options) {
     let type = undefined;
 
+    if (!_.isUndefined(options.id)) {
+      // if an ID is passed, overwrite any selection, and only process for the passed charId
+      options.selected.character = [options.id];
+    }
+
     if (options.normal) {
       type = 'normal';
     }
@@ -776,7 +781,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
         }
       };
       /* eslint-disable no-spaced-func */
-    }(token.id)), 100);
+    } (token.id)), 100);
   };
 
   this.handleChangeToken = function handleChangeToken(token) {
@@ -870,7 +875,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .groupBy(attribute => attribute.get('name').replace(/(repeating_ammo_[^_]+).*/, '$1'))
       .find(attributeList =>
         _.find(attributeList, attribute =>
-        attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
+          attribute.get('name').match(/.*name$/) && attribute.get('current') === options.ammoName)
       )
       .find(attribute => attribute.get('name').match(/.*qty$/))
       .value();
@@ -979,7 +984,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
     let msg;
 
     const bestSlot = availableSlots
-        .find(slot => parseInt(slot.get('name').match(/spell_slots_l(\d)/)[1], 10) === level) ||
+      .find(slot => parseInt(slot.get('name').match(/spell_slots_l(\d)/)[1], 10) === level) ||
       _.first(availableSlots);
 
     if (bestSlot) {
@@ -1324,7 +1329,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
 
   this.getCommandProcessor = function getCommandProcessor() {
     return cp('shaped', roll20)
-    // !shaped-config
+      // !shaped-config
       .addCommand('config', this.configure.bind(this))
       .options(configOptionsSpec)
       .option('atMenu', booleanValidator)
@@ -1380,6 +1385,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .option('normal', booleanValidator)
       .option('revert', booleanValidator)
       .option('persist', booleanValidator)
+      .option('id', getCharacterValidator(roll20), false)
       .withSelection({
         character: {
           min: 1,


### PR DESCRIPTION
Passing a character ID to the command will now process advantage tracker options for that character

usage: `!shaped-at --advantage --id <characterId>`

fixes: #88 