### PR TITLE
fix(AdvTrack): Token selection no longer required

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -728,25 +728,30 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       options.selected.character = [options.id];
     }
 
-    if (options.normal) {
-      type = 'normal';
+    if (_.isEmpty(options.selected.character)) {
+      reportError('Advantage Tracker was called, but no token was selected, and no character id was passed.');
     }
-    else if (options.advantage) {
-      type = 'advantage';
-    }
-    else if (options.disadvantage) {
-      type = 'disadvantage';
-    }
+    else {
+      if (options.normal) {
+        type = 'normal';
+      }
+      else if (options.advantage) {
+        type = 'advantage';
+      }
+      else if (options.disadvantage) {
+        type = 'disadvantage';
+      }
 
-    if (!_.isUndefined(type)) {
-      at.setRollOption(type, options.selected.character);
-    }
+      if (!_.isUndefined(type)) {
+        at.setRollOption(type, options.selected.character);
+      }
 
-    if (options.revert) {
-      at.setAutoRevert(true, options.selected.character);
-    }
-    else if (options.persist) {
-      at.setAutoRevert(false, options.selected.character);
+      if (options.revert) {
+        at.setAutoRevert(true, options.selected.character);
+      }
+      else if (options.persist) {
+        at.setAutoRevert(false, options.selected.character);
+      }
     }
   };
 
@@ -1399,7 +1404,7 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
       .option('id', getCharacterValidator(roll20), false)
       .withSelection({
         character: {
-          min: 1,
+          min: 0,
           max: Infinity,
         },
       })


### PR DESCRIPTION
A token is no longer required to be selected when calling advantage tracker.
If no token is selected, and no ID is passed, a warning error will be written to chat

fixes: #117