### PR TITLE
Fix apply defaults for token bars for creatures that have it set already

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -369,14 +369,20 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
           if (!_.isEmpty(bar.attribute)) {
             const attribute = roll20.getOrCreateAttr(character.id, bar.attribute);
             if (attribute) {
+              if (bar.link) {
+                token.set(`${barName}_link`, attribute.id);
+              }
+              else {
+                token.set(`${barName}_link`, '');
+              }
               token.set(`${barName}_value`, attribute.get('current'));
               if (bar.max) {
                 token.set(`${barName}_max`, attribute.get('max'));
               }
-              token.set(`showplayers_${barName}`, bar.showPlayers);
-              if (bar.link) {
-                token.set(`${barName}_link`, attribute.id);
+              else {
+                token.set(`${barName}_max`, '');
               }
+              token.set(`showplayers_${barName}`, bar.showPlayers);
             }
           }
         });


### PR DESCRIPTION
link needs to happen first, otherwise values get overwritten. Also need to clear max and the link if they are not set