### PR TITLE
 fix(apply-defaults): Stop bar changes causing data corruption

### DIFF
--- a/lib/shaped-script.js
+++ b/lib/shaped-script.js
@@ -370,14 +370,20 @@ function ShapedScripts(logger, myState, roll20, parser, entityLookup, reporter, 
           if (!_.isEmpty(bar.attribute)) {
             const attribute = roll20.getOrCreateAttr(character.id, bar.attribute);
             if (attribute) {
+              if (bar.link) {
+                token.set(`${barName}_link`, attribute.id);
+              }
+              else {
+                token.set(`${barName}_link`, '');
+              }
               token.set(`${barName}_value`, attribute.get('current'));
               if (bar.max) {
                 token.set(`${barName}_max`, attribute.get('max'));
               }
-              token.set(`showplayers_${barName}`, bar.showPlayers);
-              if (bar.link) {
-                token.set(`${barName}_link`, attribute.id);
+              else {
+                token.set(`${barName}_max`, '');
               }
+              token.set(`showplayers_${barName}`, bar.showPlayers);
             }
           }
         });


### PR DESCRIPTION
Previous strategy resulted in old values being written to new linked attribute
incorrectly. Also max value wasn't being reset if config was changed.