### PR TITLE
fix(chat-output): Ensure messages only get sent to correct user

### DIFF
--- a/lib/chat-watcher.js
+++ b/lib/chat-watcher.js
@@ -30,6 +30,7 @@ module.exports = class ChatWatcher {
   triggerChatListeners(msg) {
     const options = this.getRollTemplateOptions(msg);
     this.logger.debug('Roll template options: $$$', options);
+    options.playerId = msg.playerid;
     _.each(this.chatListeners, (listener) => {
       if (_.every(listener.matchers, matcher => matcher(msg, options))) {
         listener.handler(options, msg);

--- a/lib/command-parser.js
+++ b/lib/command-parser.js
@@ -200,7 +200,7 @@ class Command {
         }
       });
     }
-
+    finalOptions.playerId = playerId;
     return this.handler(finalOptions);
   }
 
@@ -272,7 +272,8 @@ function processSelection(selection, constraints, roll20, requiredCharVersion) {
   }, {});
 }
 
-module.exports = function commandParser(rootCommand, roll20, errorHandler, eventDispatcher, requiredCharVersion) {
+module.exports = function commandParser(rootCommand, roll20, errorHandler, eventDispatcher,
+  requiredCharVersion) {
   const commands = {};
 
   const cp = {
@@ -295,7 +296,8 @@ module.exports = function commandParser(rootCommand, roll20, errorHandler, event
     },
 
     addCommand(cmds, handler, gmOnly) {
-      const command = new Command(this, handler, roll20, _.isArray(cmds) ? cmds.join(',') : cmds, gmOnly);
+      const command = new Command(this, handler, roll20, _.isArray(cmds) ? cmds.join(',') : cmds,
+        gmOnly);
       (_.isArray(cmds) ? cmds : [cmds]).forEach(cmdString => (commands[cmdString] = command));
       return command;
     },

--- a/lib/event-dispatcher.js
+++ b/lib/event-dispatcher.js
@@ -3,22 +3,16 @@ const _ = require('underscore');
 
 module.exports = class EventDispatcher {
 
-  constructor(roll20, errorHandler, logger, reporter) {
+  constructor(roll20, errorHandler, logger) {
     this.roll20 = roll20;
     this.addedTokenIds = [];
     this.errorHandler = errorHandler;
     this.logger = logger;
-    this.reporter = reporter;
     this.addTokenListeners = [];
     this.attributeChangeHandlers = {};
     logger.wrapModule(this);
     roll20.on('add:token', this.handleAddToken.bind(this));
     roll20.on('change:token', this.handleChangeTokenForAdd.bind(this));
-    roll20.on('chat:message', (msg) => {
-      if (msg.playerid !== 'API') {
-        reporter.setPlayer(msg.playerid);
-      }
-    });
     roll20.on('change:attribute', (curr, prev) => {
       (this.attributeChangeHandlers[curr.get('name')] || []).forEach(handler => handler(curr, prev));
     });

--- a/lib/modules/ability-maker.js
+++ b/lib/modules/ability-maker.js
@@ -282,7 +282,7 @@ module.exports = class AbilityMaker extends ShapedModule {
   addAbility(options) {
     if (_.isEmpty(options.abilities)) {
       this.reportError('No abilities specified. ' +
-        'Take a look at the documentation for a list of ability options.');
+        'Take a look at the documentation for a list of ability options.', options.playerId);
       return;
     }
     const messages = _.map(options.selected.character, (character) => {
@@ -304,6 +304,6 @@ module.exports = class AbilityMaker extends ShapedModule {
       return message;
     });
 
-    this.reportPlayer('Ability Creation', `<ul>${messages.join('')}</ul>`);
+    this.reportPlayer('Ability Creation', `<ul>${messages.join('')}</ul>`, options.playerId);
   }
 };

--- a/lib/modules/advantage-tracker.js
+++ b/lib/modules/advantage-tracker.js
@@ -69,7 +69,8 @@ class AdvantageTracker extends ShapedModule {
     }
 
     if (_.isEmpty(options.selected.character)) {
-      this.reportError('Advantage Tracker was called, but no token was selected, and no character id was passed.');
+      this.reportError('Advantage Tracker was called, but no token was selected, and no character id was passed.',
+        options.playerId);
     }
     else {
       if (options.normal) {

--- a/lib/modules/config-ui.js
+++ b/lib/modules/config-ui.js
@@ -40,11 +40,11 @@ class ConfigUi extends ShapedModule {
     utils.deepExtend(this.myState.config, _.omit(options, 'menu'));
 
     if (options.menu) {
-      this.reportPlayer('Configuration', options.menu[0].getMenu());
+      this.reportPlayer('Configuration', options.menu[0].getMenu(), options.playerId);
     }
     else {
       const menu = new MainMenu(this.myState.config, ShapedConfig.configOptionsSpec);
-      this.reportPlayer('Configuration', menu.getMenu());
+      this.reportPlayer('Configuration', menu.getMenu(), options.playerId);
     }
   }
 }

--- a/lib/modules/importer.js
+++ b/lib/modules/importer.js
@@ -135,7 +135,8 @@ class Importer extends ShapedModule {
       .value()
       .join('</li><li>');
 
-    this.reportPlayer('Apply Defaults', `Character and token defaults applied for:<ul><li>${messageBody}</li></ul>`);
+    this.reportPlayer('Apply Defaults', `Character and token defaults applied for:<ul><li>${messageBody}</li></ul>`,
+      options.playerId);
   }
 
   importStatblock(options) {
@@ -151,11 +152,11 @@ class Importer extends ShapedModule {
             if (notes) {
               return this.processGMNotes(options, token, notes);
             }
-            return this.reportError(error);
+            return this.reportError(error, options.playerId);
           });
         }
         else {
-          return this.reportError(error);
+          return this.reportError(error, options.playerId);
         }
       }
 
@@ -171,17 +172,17 @@ class Importer extends ShapedModule {
         character.set('gmnotes', text.replace(/\n/g, '<br>'));
         return character;
       },
-    ]).then(this.displayImportResults.bind(this));
+    ]).then(this.displayImportResults.bind(this, options.playerId));
   }
 
-  displayImportResults(results) {
+  displayImportResults(playerId, results) {
     if (!_.isEmpty(results.importedList)) {
       const monsterList = results.importedList.map(char => char.get('name')).join('</li><li>');
-      this.reportPlayer('Import Success', `Added the following monsters: <ul><li>${monsterList}</li></ul>`);
+      this.reportPlayer('Import Success', `Added the following monsters: <ul><li>${monsterList}</li></ul>`, playerId);
     }
     if (!_.isEmpty(results.errors)) {
       const errorList = results.errors.join('</li><li>');
-      this.reportError(`The following errors occurred on import:  <ul><li>${errorList}</li></ul>`);
+      this.reportError(`The following errors occurred on import:  <ul><li>${errorList}</li></ul>`, playerId);
     }
   }
 
@@ -192,11 +193,11 @@ class Importer extends ShapedModule {
     }
 
     if (_.isEmpty(options.monsters)) {
-      this.showEntityPicker('monster', 'monsters');
+      this.showEntityPicker('monster', 'monsters', options.playerId);
       return null;
     }
     return this.importMonsters(options.monsters, options, options.selected.graphic, [])
-      .then(this.displayImportResults.bind(this));
+      .then(this.displayImportResults.bind(this, options.playerId));
   }
 
   importByToken(options) {
@@ -237,7 +238,7 @@ class Importer extends ShapedModule {
           message += 'The following errors were reported: <ul><li>  ' +
             `${errors.join('</li><li>')}</li></ul>`;
         }
-        this.reportPlayer('Monster Import Complete', message);
+        this.reportPlayer('Monster Import Complete', message, options.playerId);
       });
   }
 
@@ -303,7 +304,7 @@ class Importer extends ShapedModule {
 
   importSpellsFromJson(options) {
     if (_.isEmpty(options.spells)) {
-      this.showEntityPicker('spell', 'spells');
+      this.showEntityPicker('spell', 'spells', options.playerId);
       return null;
     }
 
@@ -320,7 +321,7 @@ class Importer extends ShapedModule {
           message += 'Skipped the following spells which were already present (use --overwrite to replace): <ul><li>' +
             `${_.map(skipped, spell => spell.name).join('</li><li>')}</li></ul>`;
         }
-        this.reportPlayer('Import Complete', message);
+        this.reportPlayer('Import Complete', message, options.playerId);
       });
   }
 
@@ -363,7 +364,7 @@ class Importer extends ShapedModule {
     };
   }
 
-  showEntityPicker(entityName, entityNamePlural) {
+  showEntityPicker(entityName, entityNamePlural, playerId) {
     const list = this.entityLookup.getKeys(entityNamePlural, true);
 
     if (!_.isEmpty(list)) {
@@ -373,11 +374,11 @@ class Importer extends ShapedModule {
       // create a clickable button with a roll query to select an entity from the loaded json
       this.reportPlayer(`${utils.toTitleCase(entityName)} Importer`,
         `<a href="!shaped-import-${entityName} --?{Pick a ${entityName}|${list.join('|')}}">Click to select a ` +
-        `${entityName}</a>`);
+        `${entityName}</a>`, playerId);
     }
     else {
       this.reportError(`Could not find any ${entityNamePlural}.<br/>Please ensure you have a properly formatted ` +
-        `${entityNamePlural} json file.`);
+        `${entityNamePlural} json file.`, playerId);
     }
   }
 
@@ -748,7 +749,8 @@ class Importer extends ShapedModule {
     }
 
     if (_.isEmpty(options.selected.character)) {
-      this.reportError('You have no tokens selected that represent characters, and you did not specify --all');
+      this.reportError('You have no tokens selected that represent characters, and you did not specify --all',
+        options.playerId);
       return null;
     }
     const count = options.selected.character.length;
@@ -764,7 +766,7 @@ class Importer extends ShapedModule {
       Promise.resolve())
       .then(() => {
         msg.finish();
-        this.reportPlayer('Update Complete', `${count} characters checked/updated`);
+        this.reportPlayer('Update Complete', `${count} characters checked/updated`, options.playerId);
       });
   }
 
@@ -775,7 +777,7 @@ class Importer extends ShapedModule {
       .then(() => {
         const msg = ' Spell expanded for characters: <ul><li>' +
           `${options.selected.character.map(char => char.get('name')).join('</li><li>')}</li></ul>`;
-        this.reporter.reportPlayer('Spell Expansion Complete', msg);
+        this.reporter.reportPlayer('Spell Expansion Complete', msg, options.playerId);
       });
   }
 }

--- a/lib/modules/rest-manager.js
+++ b/lib/modules/rest-manager.js
@@ -84,18 +84,17 @@ class RestManager extends ShapedModule {
       chars = [options.character];
     }
     chars.forEach((char) => {
-      const results = this.doRest(char, options.type);
-      this.roll20.sendChat(`character|${char.id}`, this.buildMessage(char, options.type, results), null,
-        { noarchive: true });
+      const results = this.doRest(char, options.type, options.playerId);
+      this.roll20.sendChat(`character|${char.id}`, this.buildMessage(char, options.type, results));
     });
   }
 
-  doRest(char, type) {
+  doRest(char, type, playerId) {
     const restIndex = this.rests.findIndex(rest => rest.name === type);
     const restsToProcess = this.rests.slice(0, restIndex + 1);
     return restsToProcess.reduce((results, rest) =>
         rest.operations
-          .map(op => op(char, rest.name))
+          .map(op => op(char, rest.name, playerId))
           .reduce((restResults, opResult) =>
             utils.extendWithArrayValues(restResults, opResult), results),
       {});
@@ -180,18 +179,18 @@ class RestManager extends ShapedModule {
     return null;
   }
 
-  recoverHP(character) {
+  recoverHP(character, playerId) {
     const charId = character.id;
     const hpAttr = this.roll20.getAttrObjectByName(charId, 'HP');
     const regained = this.recoverAttribute(hpAttr, this.myState.config.variants.rests.longRestHPRecovery,
-      character, true);
+      character, true, playerId);
 
     return {
       hp: regained,
     };
   }
 
-  recoverAttribute(attribute, multiplier, character, errorIfNoMax) {
+  recoverAttribute(attribute, multiplier, character, errorIfNoMax, playerId) {
     if (multiplier === 0 || !attribute) {
       return 0;
     }
@@ -200,7 +199,7 @@ class RestManager extends ShapedModule {
     if (!max) {
       if (errorIfNoMax) {
         this.reportError(`Can't recharge ${attribute.get('name')} for character ${character.get('name')} ` +
-          'because max value is not set');
+          'because max value is not set', playerId);
       }
       return null;
     }
@@ -211,7 +210,7 @@ class RestManager extends ShapedModule {
     return regained;
   }
 
-  recoverHD(character) {
+  recoverHD(character, playerId) {
     const charId = character.id;
     this.logger.debug('Regaining Hit Dice');
     const hitDieRegained = _.chain(this.roll20.findObjs({ type: 'attribute', characterid: charId }))
@@ -219,7 +218,7 @@ class RestManager extends ShapedModule {
       .uniq()
       .map((hdAttr) => {
         const regained = this.recoverAttribute(hdAttr, this.myState.config.variants.rests.longRestHDRecovery,
-          character);
+          character, false, playerId);
         if (regained) {
           return {
             die: hdAttr.get('name').replace(/hd_/, ''),

--- a/lib/modules/spell-manager.js
+++ b/lib/modules/spell-manager.js
@@ -18,7 +18,7 @@ module.exports = class SpellManager extends ShapedModule {
     const castingLevel = parseInt(options.castAsLevel, 10);
     if (_.isNaN(castingLevel)) {
       this.logger.error('Bad casting level [$$$]', options.castAsLevel);
-      this.reportError('An error occured with spell slots, see the log for more details');
+      this.reportError('An error occured with spell slots, see the log for more details', options.playerId);
       return;
     }
 

--- a/lib/modules/uses-manager.js
+++ b/lib/modules/uses-manager.js
@@ -22,7 +22,7 @@ class UsesManager extends ShapedModule {
     let perUse = parseInt(options.perUse || 1, 10);
     if (_.isNaN(perUse)) {
       this.reportError(`Character ${options.characterName} has an invalid 'Per Use" value [${options.perUse}] for ` +
-        `${options.title} so uses could not be decremented.`);
+        `${options.title} so uses could not be decremented.`, options.playerId);
       return;
     }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -39,29 +39,25 @@ class Reporter {
     this.scriptName = scriptName;
   }
 
-  setPlayer(playerId) {
-    this.playerId = playerId;
-  }
-
   reportPublic(heading, text) {
     this.roll20.sendChat('', `${makeNormalMessage(heading, text)}`);
   }
 
-  reportPlayer(heading, text) {
-    this.roll20.sendChat('', `/w ${this.getPlayerName()} ${makeNormalMessage(heading, text)}`, null,
+  reportPlayer(heading, text, playerId) {
+    this.roll20.sendChat('', `/w ${this.getPlayerName(playerId)} ${makeNormalMessage(heading, text)}`, null,
       { noarchive: true });
   }
 
-  reportError(text) {
-    this.roll20.sendChat('', `/w ${this.getPlayerName()} ${makeErrorMessage(this.scriptName, text)}`, null,
+  reportError(text, playerId) {
+    this.roll20.sendChat('', `/w ${this.getPlayerName(playerId)} ${makeErrorMessage(this.scriptName, text)}`, null,
       { noarchive: true });
   }
 
-  getPlayerName() {
-    return this.playerId ? `"${this.roll20.getObj('player', this.playerId).get('displayname')}"` : 'gm';
+  getPlayerName(playerId) {
+    return playerId ? `"${this.roll20.getObj('player', playerId).get('displayname')}"` : 'gm';
   }
 
-  getMessageBuilder(heading, isPublic) {
+  getMessageBuilder(heading, isPublic, playerId) {
     const fields = {};
     const reporter = this;
     return {
@@ -70,14 +66,14 @@ class Reporter {
       },
       display() {
         const displayer = (isPublic ? reporter.reportPublic : reporter.reportPlayer).bind(reporter);
-        displayer(heading, _.reduce(fields, (text, content, name) => `${text}{{${name}=${content}}}`, ''));
+        displayer(playerId, _.reduce(fields, (text, content, name) => `${text}{{${name}=${content}}}`, ''));
       },
     };
   }
 
-  getMessageStreamer(heading) {
+  getMessageStreamer(heading, playerId) {
     const sendChat = (text) => {
-      this.roll20.sendChat('', `/w ${this.getPlayerName()} ${text}`, null, { noarchive: true });
+      this.roll20.sendChat('', `/w ${this.getPlayerName(playerId)} ${text}`, null, { noarchive: true });
     };
 
     sendChat(makeStreamHeader(heading));

--- a/lib/shaped-module.js
+++ b/lib/shaped-module.js
@@ -26,12 +26,12 @@ module.exports = class ShapedModule {
     this.reporter.reportPublic(heading, text);
   }
 
-  reportPlayer(heading, text) {
-    this.reporter.reportPlayer(heading, text);
+  reportPlayer(heading, text, playerId) {
+    this.reporter.reportPlayer(heading, text, playerId);
   }
 
-  reportError(text) {
-    this.reporter.reportError(text);
+  reportError(text, playerId) {
+    this.reporter.reportError(text, playerId);
   }
 
   get logWrap() {

--- a/test/test-command-parser.js
+++ b/test/test-command-parser.js
@@ -40,13 +40,14 @@ describe('command-parser', function () {
             ],
           },
         })
-        .processCommand({ content: '!shaped-config --foo.subThree.flurb[1] splat', type: 'api' });
+        .processCommand({ content: '!shaped-config --foo.subThree.flurb[1] splat', type: 'api', playerid: 1 });
       const expected = {
         foo: {
           subThree: {
             flurb: [],
           },
         },
+        playerId: 1,
       };
       expected.foo.subThree.flurb[1] = 'splat';
       expect(result).to.deep.equal(expected);
@@ -68,8 +69,9 @@ describe('command-parser', function () {
       });
 
     it('handles comma-sep options', function () {
-      myCp.processCommand({ content: '!shaped-stuff --key1, key2', type: 'api' });
+      myCp.processCommand({ content: '!shaped-stuff --key1, key2', type: 'api', playerid: 1 });
       expect(result).to.deep.equal({
+        playerId: 1,
         spells: ['value1', 'value2'],
       });
     });
@@ -89,8 +91,8 @@ describe('command-parser', function () {
         })
         .option('test', testValidator, true);
 
-      myCp.processCommand({ content: '!shaped-stuff --test', type: 'api' });
-      expect(result).to.deep.equal({ test: true });
+      myCp.processCommand({ content: '!shaped-stuff --test', type: 'api', playerid: 1 });
+      expect(result).to.deep.equal({ test: true, playerId: 1 });
     });
   });
 });


### PR DESCRIPTION
Error and result messages were sometimes being sent to other players when
multiple users were chatting at the same time as commands were being run
Refactored the way the playerId is associated with commands to ensure this
doesn't happen any more.